### PR TITLE
daemon -> daemonize

### DIFF
--- a/hpc05/connect.py
+++ b/hpc05/connect.py
@@ -97,7 +97,7 @@ def start_ipcluster(n, profile, env_path=None, timeout=300):
         ipcluster = os.path.join(os.path.expanduser(env_path), "bin", ipcluster)
 
     print(f"Launching {n} engines in a ipcluster.")
-    cmd = f"{ipcluster} start --profile={profile} --n={n} --log-to-file --daemon &"
+    cmd = f"{ipcluster} start --profile={profile} --n={n} --log-to-file --daemonize &"
 
     # For an unknown reason `subprocess.Popen(cmd.split())` doesn't work when
     # running `start_remote_ipcluster` and connecting to it, so we use os.system.


### PR DESCRIPTION
It seems the correct flag to use with `ipcluster` is `daemonize`, not `daemon`. See [here](https://github.com/ipython/ipyparallel/blob/f2c10970b782b60b2f2ec04e95ab88d204d6c6b9/ipyparallel/apps/ipclusterapp.py#L216).